### PR TITLE
Dynamic delay when applying new parameters

### DIFF
--- a/LoadbalanceEVCharger.yaml
+++ b/LoadbalanceEVCharger.yaml
@@ -8,9 +8,15 @@ triggers:
       - input_select.ev_charge_mode
       - input_number.ev_load_balancing_power_limit
 conditions:
-  - condition: state
-    entity_id: sensor.alfen_eve_connection_state
-    state: Connected
+  - condition: and
+    conditions:
+      - condition: state
+        entity_id: sensor.alfen_eve_connection_state
+        state: Connected
+      - condition: template
+        value_template: >-
+          {{ (state_attr('automation.load_balance_ev_charging', 'current') ==
+          0) | bool }}
 actions:
   - variables:
       home_power: "{{ states('sensor.netto_verbruik_huis_lp') | int }}"

--- a/LoadbalanceEVCharger.yaml
+++ b/LoadbalanceEVCharger.yaml
@@ -8,15 +8,9 @@ triggers:
       - input_select.ev_charge_mode
       - input_number.ev_load_balancing_power_limit
 conditions:
-  - condition: and
-    conditions:
-      - condition: state
-        entity_id: sensor.alfen_eve_connection_state
-        state: Connected
-      - condition: template
-        value_template: >-
-          {{ (state_attr('automation.load_balance_ev_charging', 'current') ==
-          0) | bool }}
+  - condition: state
+    entity_id: sensor.alfen_eve_connection_state
+    state: Connected
 actions:
   - variables:
       home_power: "{{ states('sensor.netto_verbruik_huis_lp') | int }}"

--- a/SetChargerParams.yaml
+++ b/SetChargerParams.yaml
@@ -7,7 +7,6 @@ sequence:
         {% else %}
           {{ current }}
         {% endif %}
-      max_delays: 30
   - parallel:
       - alias: Set phases
         if:
@@ -21,6 +20,8 @@ sequence:
               {{ phase !=
               states('select.alfen_eve_installation_max_allowed_phases') }}
         then:
+          - variables:
+              max_delays: 60
           - action: select.select_option
             metadata: {}
             data:
@@ -55,6 +56,8 @@ sequence:
               int }}
             enabled: true
         then:
+          - variables:
+              max_delays: 30
           - action: number.set_value
             metadata: {}
             data:

--- a/SetChargerParams.yaml
+++ b/SetChargerParams.yaml
@@ -7,6 +7,7 @@ sequence:
         {% else %}
           {{ current }}
         {% endif %}
+      max_delays: 30
   - parallel:
       - alias: Set phases
         if:
@@ -26,12 +27,20 @@ sequence:
               option: "{{ phase }}"
             target:
               entity_id: select.alfen_eve_installation_max_allowed_phases
-          - delay:
-              hours: 0
-              minutes: 1
-              seconds: 0
-              milliseconds: 0
-            enabled: true
+          - repeat:
+              sequence:
+                - delay:
+                    hours: 0
+                    minutes: 0
+                    seconds: 1
+                    milliseconds: 0
+                  enabled: true
+              until:
+                - condition: template
+                  value_template: >-
+                    {{
+                    states('sensor.alfen_eve_connector_1_max_allowed_of_phases')
+                    == phase or repeat.index >= max_delays }}
       - alias: Set current
         if:
           - condition: template
@@ -52,12 +61,20 @@ sequence:
               value: "{{ finalcurrent }}"
             target:
               entity_id: number.alfen_eve_power_connector_max_current_socket_1
-          - delay:
-              hours: 0
-              minutes: 0
-              seconds: 30
-              milliseconds: 0
-            enabled: true
+          - repeat:
+              sequence:
+                - delay:
+                    hours: 0
+                    minutes: 0
+                    seconds: 1
+                    milliseconds: 0
+                  enabled: true
+              until:
+                - condition: template
+                  value_template: >-
+                    {{
+                    states('sensor.alfen_eve_main_external_max_current_socket_1')
+                    | int == finalcurrent | int or repeat.index >= max_delays }}
 description: Set the Alfen Eve Pro current and phase
 icon: mdi:ev-station
 fields:


### PR DESCRIPTION
Changes the static busy waiting delay (could cause issues with alfen plugin) to a dynamic delay when setting the parameters.
By default we will wait 30 seconds in iteration of 1 second.